### PR TITLE
Copy artifacts update

### DIFF
--- a/build/copyArtifacts.bash
+++ b/build/copyArtifacts.bash
@@ -36,11 +36,11 @@ echo "Copying build artifacts to ${releaseFolder}"
 cp ${dependenciesFolder}/imgui-sfml-build/libImGui-SFML.dll ${releaseFolder}
 cp ${dependenciesFolder}/zlib-build/libzlib1.dll ${releaseFolder}
 cp ${dependenciesFolder}/luajit-build/src/libluajit.dll ${releaseFolder}
-cp ${dependenciesFolder}/sfml-build/lib/sfml-audio-2.dll ${releaseFolder}
-cp ${dependenciesFolder}/sfml-build/lib/sfml-graphics-2.dll ${releaseFolder}
-cp ${dependenciesFolder}/sfml-build/lib/sfml-network-2.dll ${releaseFolder}
-cp ${dependenciesFolder}/sfml-build/lib/sfml-system-2.dll ${releaseFolder}
-cp ${dependenciesFolder}/sfml-build/lib/sfml-window-2.dll ${releaseFolder}
+cp ${dependenciesFolder}/sfml-build/lib/sfml-audio-3.dll ${releaseFolder}
+cp ${dependenciesFolder}/sfml-build/lib/sfml-graphics-3.dll ${releaseFolder}
+cp ${dependenciesFolder}/sfml-build/lib/sfml-network-3.dll ${releaseFolder}
+cp ${dependenciesFolder}/sfml-build/lib/sfml-system-3.dll ${releaseFolder}
+cp ${dependenciesFolder}/sfml-build/lib/sfml-window-3.dll ${releaseFolder}
 cp ${dependenciesFolder}/libsodium-cmake-build/libsodium.dll ${releaseFolder}
 cp ${dependenciesFolder}/sfml-src/extlibs/bin/x64/openal32.dll ${releaseFolder}
 # Copy some DLLs from our MSYS system


### PR DESCRIPTION
sfml-build dlls are now on 3, up from 2, so the current copyArtifacts.bash doesn't locate them correctly and will fail to copy them. This fixes that