### PR TITLE
Organize replays into folders

### DIFF
--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -1031,10 +1031,10 @@ void HexagonGame::death_sendAndSaveReplay(const replay_file& rf)
 [[nodiscard]] bool HexagonGame::death_saveReplay(
     const std::string& filename, const compressed_replay_file& crf)
 {
-    std::filesystem::create_directory("Replays/");
-
+    std::string dirPath = "Replays/" + levelId + "/" + diffFormat(difficultyMult) + "x/";
+    std::filesystem::create_directories(dirPath);
     std::filesystem::path p;
-    p /= "Replays/";
+    p /= dirPath;
     p /= filename;
 
     if(!crf.serialize_to_file(p))


### PR DESCRIPTION
A really small change that makes it so replays are now saved under `Replays/levelId/difficultyMult/`, rather than just `/Replays`.
Example: A replay for Incongruence at 0.5x would be saved under `Replays\ohvrvanilla_vittorio_romeo_hypercube_1_incongruence\0.5x\replayName.ohr.z`

Tested and confirmed functional, and a quick code read indicates that it should not affect uploading to leaderboards (I seem to be unable to actually test this locally however, I assume logging in to the server is disabled via the github build)