### PR TITLE
add lua function to get scores

### DIFF
--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -169,6 +169,15 @@ void HexagonGame::initLua_Utils()
         .doc(
             "Force-swaps (180 degrees) the player when invoked. If `$0` is "
             "`true`, the swap sound will be played.");
+
+    addLuaFn(lua, "u_getScore",
+        [this](const std::string& mId)
+        {
+            return assets.getCurrentLocalProfile().getScore(mId);
+        }
+    )
+    .arg("levelId")
+    .doc("Gets the score of a level. A levelId is for example `pointless_m_3`");
 }
 
 void HexagonGame::initLua_AudioControl()


### PR DESCRIPTION
This would allow for progression in level packs. I wasn't sure if you should be able to only get scores of your own pack, but since I don't think it's an issue if you can see other scores and it's easier to implement that way too, I think it's fine.