### PR TITLE
Add onPreUnload core function

### DIFF
--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -205,6 +205,7 @@ private:
     std::optional<SwapParticleSpawnInfo> swapParticlesSpawnInfo;
     float nextPBParticleSpawn{0.f};
     float pbTextGrowth{0.f};
+    float messageTextCharacterSize{32.f};
 
     sf::Sprite keyIconLeft;
     sf::Sprite keyIconRight;

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -387,6 +387,7 @@ private:
     void drawTrailParticles();
     void drawSwapParticles();
     void drawImguiLuaConsole();
+    void drawMainLayer(const auto getRenderStates);
 
     // Data-related methods
     void setLevelData(const LevelData& mLevelData, bool mMusicFirstPlay);
@@ -430,6 +431,9 @@ private:
     Utils::FastVertexVectorTris pivotQuads;
     Utils::FastVertexVectorTris playerTris;
     Utils::FastVertexVectorTris capTris;
+    Utils::FastVertexVectorTris wallQuads3DTop;
+    Utils::FastVertexVectorTris pivotQuads3DTop;
+    Utils::FastVertexVectorTris playerTris3DTop;
     Utils::FastVertexVectorTris wallQuads3D;
     Utils::FastVertexVectorTris pivotQuads3D;
     Utils::FastVertexVectorTris playerTris3D;

--- a/include/SSVOpenHexagon/Data/StyleData.hpp
+++ b/include/SSVOpenHexagon/Data/StyleData.hpp
@@ -78,6 +78,8 @@ public:
 
     float _3dDepth{};
     float _3dLayerOffset{};
+    bool _3dAlphaMirror{};
+    bool _3dMainOnTop{};
     float _3dSkew{};
     float _3dSpacing{};
     float _3dDarkenMult{};

--- a/include/SSVOpenHexagon/Data/StyleData.hpp
+++ b/include/SSVOpenHexagon/Data/StyleData.hpp
@@ -77,6 +77,7 @@ public:
     float maxSwapTime{};
 
     float _3dDepth{};
+    float _3dLayerOffset{};
     float _3dSkew{};
     float _3dSpacing{};
     float _3dDarkenMult{};

--- a/include/SSVOpenHexagon/Global/Assets.hpp
+++ b/include/SSVOpenHexagon/Global/Assets.hpp
@@ -110,6 +110,8 @@ private:
         const std::string& mPackId, const ssvufs::Path& mPath);
     void loadPackAssets_loadCustomSounds(
         const std::string& mPackId, const ssvufs::Path& mPath);
+    void loadPackAssets_loadCustomFonts(
+        const std::string& mPackId, const ssvufs::Path& mPath);
 
     [[nodiscard]] std::string getCurrentLocalProfileFilePath();
 

--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -617,7 +617,7 @@ void HexagonGame::updateText(ssvu::FT mFT)
         fpsText.setCharacterSize(getScaledCharacterSize(20.f));
     }
 
-    messageText.setCharacterSize(getScaledCharacterSize(32.f));
+    messageText.setCharacterSize(getScaledCharacterSize(messageTextCharacterSize));
     messageText.setOrigin({ssvs::getGlobalWidth(messageText) / 2.f, 0.f});
 
     const float growth = std::sin(pbTextGrowth);

--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -191,8 +191,9 @@ void HexagonGame::draw()
             const float i(depth - j - 1);
 
             const float offset(styleData._3dSpacing *
-                               (float(i + 1.f) * styleData._3dPerspectiveMult) *
-                               (effect * 3.6f) * 1.4f);
+                               (float(i + 1.f + styleData._3dLayerOffset) *
+				styleData._3dPerspectiveMult) * (effect * 3.6f)
+			       * 1.4f);
 
             const sf::Vector2f newPos(offset * cosRot, offset * sinRot);
 

--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -165,9 +165,12 @@ void HexagonGame::draw()
             playerTris3DTop.reserve(numPlayerTris * aboveMain);
         }
 
-        wallQuads3D.reserve(numWallQuads * depth);
-        pivotQuads3D.reserve(numPivotQuads * depth);
-        playerTris3D.reserve(numPlayerTris * depth);
+        if(depth > 0)
+        {
+            wallQuads3D.reserve(numWallQuads * depth);
+            pivotQuads3D.reserve(numPivotQuads * depth);
+            playerTris3D.reserve(numPlayerTris * depth);
+        }
 
         const float pulse3D{Config::getNoPulse() ? 1.f : status.pulse3D};
         const float effect{
@@ -214,7 +217,7 @@ void HexagonGame::draw()
             j < static_cast<int>(renderAbove ? depth + aboveMain : depth); ++j)
         {
             const bool renderingAbove(j >= depth && renderAbove);
-            const float jAdj(j - depth * renderingAbove);
+            const float jAdj(j - depth * renderingAbove * (depth >= 0));
             const float i(depth - j - 1 + layerOffset);
 
             const float offset(styleData._3dSpacing *

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -176,12 +176,14 @@ void HexagonGame::initLua_Utils()
                 assets.getFontOrNullFont(getPackId() + "_" + mFontId));
         })
         .arg("fontId")
-        .doc("");
+        .doc(
+            "Sets the font messages will use to `$0` which is the filename of "
+            "a file inside the `Fonts` folder in your pack.");
 
     addLuaFn(lua, "u_setMessageFontSize", //
         [this](float mSize) { messageTextCharacterSize = mSize; })
         .arg("size")
-        .doc("");
+        .doc("Sets the font size messages will use to `$0`.");
 }
 
 void HexagonGame::initLua_AudioControl()

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -169,6 +169,19 @@ void HexagonGame::initLua_Utils()
         .doc(
             "Force-swaps (180 degrees) the player when invoked. If `$0` is "
             "`true`, the swap sound will be played.");
+
+    addLuaFn(lua, "u_setMessageFont", //
+        [this](std::string mFontId) {
+            messageText.setFont(
+                assets.getFontOrNullFont(getPackId() + "_" + mFontId));
+        })
+        .arg("fontId")
+        .doc("");
+
+    addLuaFn(lua, "u_setMessageFontSize", //
+        [this](float mSize) { messageTextCharacterSize = mSize; })
+        .arg("size")
+        .doc("");
 }
 
 void HexagonGame::initLua_AudioControl()

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -700,6 +700,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
     inputImplCCW = inputImplCW = false;
     playerNowReadyToSwap = false;
 
+    runLuaFunctionIfExists<void>("onPreUnload");
     lua = Lua::LuaContext{};
     calledDeprecatedFunctions.clear();
     initLua();

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -633,6 +633,9 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
 
     debugPause = false;
 
+    // Font cleanup
+    messageText.setFont(font);
+
     // Events cleanup
     messageText.setString("");
     pbText.setString("");

--- a/src/SSVOpenHexagon/Core/LuaScripting.cpp
+++ b/src/SSVOpenHexagon/Core/LuaScripting.cpp
@@ -1038,6 +1038,11 @@ static void initStyleControl(Lua::LuaContext& lua, StyleData& styleData)
 
         "Sets the amount of 3D layers in a style to `$0`.");
 
+    sdVar("3dLayerOffset", &StyleData::_3dLayerOffset,
+        "Gets the current offset of the 3D layers compared to where they usually are in layers (partial layers are valid too).",
+
+        "Sets the current offset of the 3D layers to `$0`.");
+
     sdVar("3dSkew", &StyleData::_3dSkew,
         "Gets the current value of where the 3D skew is in the style. The Skew "
         "is what gives the 3D effect in the first "

--- a/src/SSVOpenHexagon/Core/LuaScripting.cpp
+++ b/src/SSVOpenHexagon/Core/LuaScripting.cpp
@@ -1039,9 +1039,19 @@ static void initStyleControl(Lua::LuaContext& lua, StyleData& styleData)
         "Sets the amount of 3D layers in a style to `$0`.");
 
     sdVar("3dLayerOffset", &StyleData::_3dLayerOffset,
-        "Gets the current offset of the 3D layers compared to where they usually are in layers (partial layers are valid too).",
+        "Gets the current offset of the 3D layers compared to where they usually are in layers.",
 
         "Sets the current offset of the 3D layers to `$0`.");
+
+    sdVar("3dAlphaMirror", &StyleData::_3dAlphaMirror,
+        "Gets if the alpha of the 3D layers above the main layer should be mirrored (has no effect with 3dLayerOffset >= -1).",
+
+        "Sets if the alpha of the 3D layers above the main layer should be mirrored.");
+
+    sdVar("3dMainOnTop", &StyleData::_3dMainOnTop,
+        "Gets if the main layer should be rendered on top of all 3D layers (has no effect with 3_3dLayerOffset >= -1).",
+
+        "Sets if the main layer should be rendered on top of all 3D layers.");
 
     sdVar("3dSkew", &StyleData::_3dSkew,
         "Gets the current value of where the 3D skew is in the style. The Skew "

--- a/src/SSVOpenHexagon/Data/StyleData.cpp
+++ b/src/SSVOpenHexagon/Data/StyleData.cpp
@@ -44,6 +44,7 @@ StyleData::StyleData(const ssvuj::Obj& mRoot)
       maxSwapTime{ssvuj::getExtr<float>(mRoot, "max_swap_time", 100.f)},
 
       _3dDepth{ssvuj::getExtr<float>(mRoot, "3D_depth", 15.f)},
+      _3dLayerOffset{ssvuj::getExtr<float>(mRoot, "3D_layer_offset", 0.f)},
       _3dSkew{ssvuj::getExtr<float>(mRoot, "3D_skew", 0.18f)},
       _3dSpacing{ssvuj::getExtr<float>(mRoot, "3D_spacing", 1.f)},
       _3dDarkenMult{ssvuj::getExtr<float>(mRoot, "3D_darken_multiplier", 1.5f)},

--- a/src/SSVOpenHexagon/Data/StyleData.cpp
+++ b/src/SSVOpenHexagon/Data/StyleData.cpp
@@ -45,6 +45,8 @@ StyleData::StyleData(const ssvuj::Obj& mRoot)
 
       _3dDepth{ssvuj::getExtr<float>(mRoot, "3D_depth", 15.f)},
       _3dLayerOffset{ssvuj::getExtr<float>(mRoot, "3D_layer_offset", 0.f)},
+      _3dAlphaMirror{ssvuj::getExtr<bool>(mRoot, "3D_alpha_mirror", true)},
+      _3dMainOnTop{ssvuj::getExtr<bool>(mRoot, "3D_main_on_top", false)},
       _3dSkew{ssvuj::getExtr<float>(mRoot, "3D_skew", 0.18f)},
       _3dSpacing{ssvuj::getExtr<float>(mRoot, "3D_spacing", 1.f)},
       _3dDarkenMult{ssvuj::getExtr<float>(mRoot, "3D_darken_multiplier", 1.5f)},

--- a/src/SSVOpenHexagon/Global/Assets.cpp
+++ b/src/SSVOpenHexagon/Global/Assets.cpp
@@ -311,6 +311,11 @@ HGAssets::~HGAssets()
             {
                 loadPackAssets_loadCustomSounds(packId, packPath);
             }
+
+            if(!levelsOnly && ssvufs::Path{packPath + "Fonts/"}.isFolder())
+            {
+                loadPackAssets_loadCustomFonts(packId, packPath);
+            }
         }
 
         if(ssvufs::Path{packPath + "Music/"}.isFolder() && !levelsOnly)
@@ -734,6 +739,22 @@ void HGAssets::loadPackAssets_loadCustomSounds(
     }
 }
 
+void HGAssets::loadPackAssets_loadCustomFonts(
+    const std::string& mPackId, const ssvufs::Path& mPath)
+{
+    for(const auto& p : scanSingleByExt(mPath + "Fonts/", ".ttf"))
+    {
+        if(!assetStorage->loadFont(
+               concatIntoBuf(mPackId, '_', p.getFileName()), p))
+        {
+            ssvu::lo("hg::loadPackAssets_loadCustomFonts")
+                << "Failed to load font '" << p << "'\n";
+        }
+
+        ++loadInfo.assets;
+    }
+}
+
 void HGAssets::loadPackAssets_loadMusic(
     const std::string& mPackId, const ssvufs::Path& mPath)
 {
@@ -1072,6 +1093,27 @@ void HGAssets::reloadAllShaders()
             }
         }
         output += "Custom sound files successfully reloaded\n";
+    }
+
+    // Custom fonts
+    temp = mPath + "Fonts/";
+    if(!ssvufs::Path{temp}.isFolder())
+    {
+        output += "invalid custom font path\n";
+    }
+    else
+    {
+        for(const auto& p : scanSingleByExt(mPath + "Fonts/", ".ttf"))
+        {
+            temp = mPackId + "_" + p.getFileName();
+            if(!assetStorage->loadFont(temp, p))
+            {
+                output += "Failed to load font '";
+                output += p;
+                output += "'\n";
+            }
+        }
+        output += "Custom font files successfully reloaded\n";
     }
 
     return output;


### PR DESCRIPTION
I'm not sure if I should put all changes for parity in one big pull request rather than a lot of small ones now, but here is another one either way. This change is very specific to allow the function to run after timeline, levelStatus and a few other things have already been reset, while the lua environment has not. This way levels can actually access their lua variables when unloading, the old onUnload is kept for backwards compatability as well as the ability to tell if an attempt is a first attempt. This is also a very important change to make the level_change event that I implemented in my converter function properly since it needs to restart in the level it changed (There is a level that heavily relies on this mechanic.).