### PR TITLE
Add onPreUnload core function

### DIFF
--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -700,6 +700,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
     inputImplCCW = inputImplCW = false;
     playerNowReadyToSwap = false;
 
+    runLuaFunctionIfExists<void>("onPreUnload");
     lua = Lua::LuaContext{};
     calledDeprecatedFunctions.clear();
     initLua();

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -700,7 +700,7 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
     inputImplCCW = inputImplCW = false;
     playerNowReadyToSwap = false;
 
-    runLuaFunctionIfExists<void>("onPreUnload");
+    if(!firstPlay) runLuaFunctionIfExists<void>("onPreUnload");
     lua = Lua::LuaContext{};
     calledDeprecatedFunctions.clear();
     initLua();


### PR DESCRIPTION
I'm not sure if I should put all changes for parity in one big pull request rather than a lot of small ones now, but here is another one either way. This change is very specific to allow the function to run after timeline, levelStatus and a few other things have already been reset, while the lua environment has not. This way levels can actually access their lua variables when unloading, the old onUnload is kept for backwards compatability as well as the ability to tell if an attempt is a first attempt. This is also a very important change to make the level_change event that I implemented in my converter function properly since it needs to restart in the level it changed (There is a level that heavily relies on this mechanic.).