### PR TITLE
add frametime parameter to onRenderStage

### DIFF
--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -72,7 +72,8 @@ void HexagonGame::draw()
             return sf::RenderStates::Default;
         }
 
-        runLuaFunctionIfExists<int>("onRenderStage", static_cast<int>(rs));
+        runLuaFunctionIfExists<int, float>(
+            "onRenderStage", static_cast<int>(rs), 60.f / window->getFPS());
         return sf::RenderStates{assets.getShaderByShaderId(*fragmentShaderId)};
     };
 


### PR DESCRIPTION
This is another small one. It just gives the onRenderStage core function frametime as second parameter which allows for more accurately timed shader effects, since `l_getLevelTime()` only updates 240 times per second.