### PR TITLE
Make manual (Beat)Pulse control update immediately

### DIFF
--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -353,7 +353,9 @@ private:
     void updateCustomTimelines();
     void updateCustomWalls(ssvu::FT mFT);
     void updatePulse(ssvu::FT mFT);
+    void setPulse();
     void updateBeatPulse(ssvu::FT mFT);
+    void setBeatPulse();
     void updateRotation(ssvu::FT mFT);
     void updateCameraShake(ssvu::FT mFT);
     void updateFlash(ssvu::FT mFT);

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -353,9 +353,9 @@ private:
     void updateCustomTimelines();
     void updateCustomWalls(ssvu::FT mFT);
     void updatePulse(ssvu::FT mFT);
-    void setPulse();
+    void refreshPulse();
     void updateBeatPulse(ssvu::FT mFT);
-    void setBeatPulse();
+    void refreshBeatPulse();
     void updateRotation(ssvu::FT mFT);
     void updateCameraShake(ssvu::FT mFT);
     void updateFlash(ssvu::FT mFT);

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -1076,34 +1076,22 @@ void HexagonGame::initLua_Deprecated()
             "**This function is deprecated and will be removed in a future "
             "version. Please use e_clearMessages instead!**");
 
-    addLuaFn(lua, "l_getPulse", [this] { return status.pulse; })
-        .doc(
-            "Gets the current pulse value, which will vary between "
-            "`l_getPulseMin()` and `l_getPulseMax()` unless manually "
-            "overridden.");
-
-    addLuaFn(lua, "l_setPulse",
+    addLuaFn(lua, "l_forceSetPulse",
         [this](const float mValue)
         {
             status.pulse = mValue;
-            setPulse();
+            refreshPulse();
         })
-        .doc("Sets the current pulse value to `$0`.");
+        .doc("Immediately sets the current pulse value to `$0`.");
 
-    addLuaFn(lua, "l_getBeatPulse", [this] { return status.beatPulse; })
-        .doc(
-            "Gets the current beat pulse value, which will vary between `0` "
-            "and "
-            "`l_getBeatPulseMax()` unless manually overridden.");
-
-    addLuaFn(lua, "l_setBeatPulse",
+    addLuaFn(lua, "l_forceSetBeatPulse",
         [this](const float mValue)
         {
             status.beatPulse = mValue;
-            setBeatPulse();
+            refreshBeatPulse();
             player.updatePosition(status.radius);
         })
-        .doc("Sets the current beat pulse value to `$0`.");
+        .doc("Immediately sets the current beat pulse value to `$0`.");
 }
 
 void HexagonGame::initLua()

--- a/src/SSVOpenHexagon/Core/HGScripting.cpp
+++ b/src/SSVOpenHexagon/Core/HGScripting.cpp
@@ -1075,6 +1075,35 @@ void HexagonGame::initLua_Deprecated()
             "Remove all previously scheduled messages. "
             "**This function is deprecated and will be removed in a future "
             "version. Please use e_clearMessages instead!**");
+
+    addLuaFn(lua, "l_getPulse", [this] { return status.pulse; })
+        .doc(
+            "Gets the current pulse value, which will vary between "
+            "`l_getPulseMin()` and `l_getPulseMax()` unless manually "
+            "overridden.");
+
+    addLuaFn(lua, "l_setPulse",
+        [this](const float mValue)
+        {
+            status.pulse = mValue;
+            setPulse();
+        })
+        .doc("Sets the current pulse value to `$0`.");
+
+    addLuaFn(lua, "l_getBeatPulse", [this] { return status.beatPulse; })
+        .doc(
+            "Gets the current beat pulse value, which will vary between `0` "
+            "and "
+            "`l_getBeatPulseMax()` unless manually overridden.");
+
+    addLuaFn(lua, "l_setBeatPulse",
+        [this](const float mValue)
+        {
+            status.beatPulse = mValue;
+            setBeatPulse();
+            player.updatePosition(status.radius);
+        })
+        .doc("Sets the current beat pulse value to `$0`.");
 }
 
 void HexagonGame::initLua()

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -762,8 +762,12 @@ void HexagonGame::updatePulse(ssvu::FT mFT)
         }
 
         status.pulseDelay -= mFT * getMusicDMSyncFactor();
+        setPulse();
     }
+}
 
+void HexagonGame::setPulse()
+{
     if(window != nullptr)
     {
         SSVOH_ASSERT(backgroundCamera.has_value());
@@ -799,8 +803,12 @@ void HexagonGame::updateBeatPulse(ssvu::FT mFT)
             status.beatPulse -= (2.f * mFT * getMusicDMSyncFactor()) *
                                 levelStatus.beatPulseSpeedMult;
         }
+        setBeatPulse();
     }
+}
 
+void HexagonGame::setBeatPulse()
+{
     const float radiusMin{Config::getBeatPulse() ? levelStatus.radiusMin : 75};
     status.radius =
         radiusMin * (status.pulse / levelStatus.pulseMin) + status.beatPulse;

--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -762,11 +762,11 @@ void HexagonGame::updatePulse(ssvu::FT mFT)
         }
 
         status.pulseDelay -= mFT * getMusicDMSyncFactor();
-        setPulse();
+        refreshPulse();
     }
 }
 
-void HexagonGame::setPulse()
+void HexagonGame::refreshPulse()
 {
     if(window != nullptr)
     {
@@ -803,11 +803,11 @@ void HexagonGame::updateBeatPulse(ssvu::FT mFT)
             status.beatPulse -= (2.f * mFT * getMusicDMSyncFactor()) *
                                 levelStatus.beatPulseSpeedMult;
         }
-        setBeatPulse();
+        refreshBeatPulse();
     }
 }
 
-void HexagonGame::setBeatPulse()
+void HexagonGame::refreshBeatPulse()
 {
     const float radiusMin{Config::getBeatPulse() ? levelStatus.radiusMin : 75};
     status.radius =

--- a/src/SSVOpenHexagon/Core/LuaScripting.cpp
+++ b/src/SSVOpenHexagon/Core/LuaScripting.cpp
@@ -934,7 +934,6 @@ static void initLevelControl(
 
         "Sets the current beat pulse value to `$0`.");
 
-
     sVar("BeatPulseDelay", &HexagonGameStatus::beatPulseDelay,
         "Gets the current beat pulse delay value, which will vary between "
         "`0` and `l_getBeatPulseDelayMax()` unless manually overridden.",

--- a/src/SSVOpenHexagon/Core/LuaScripting.cpp
+++ b/src/SSVOpenHexagon/Core/LuaScripting.cpp
@@ -909,12 +909,6 @@ static void initLevelControl(
 
     const auto sVar = makeLuaAccessor(lua, status, "l");
 
-    sVar("Pulse", &HexagonGameStatus::pulse,
-        "Gets the current pulse value, which will vary between "
-        "`l_getPulseMin()` and `l_getPulseMax()` unless manually overridden.",
-
-        "Sets the current pulse value to `$0`.");
-
     sVar("PulseDirection", &HexagonGameStatus::pulseDirection,
         "Gets the current pulse direction value, which will either be `-1` or "
         "`1` unless manually overridden.",
@@ -927,12 +921,6 @@ static void initLevelControl(
         "`0` and `l_getPulseDelayMax()` unless manually overridden.",
 
         "Sets the current pulse delay value to `$0`.");
-
-    sVar("BeatPulse", &HexagonGameStatus::beatPulse,
-        "Gets the current beat pulse value, which will vary between `0` and "
-        "`l_getBeatPulseMax()` unless manually overridden.",
-
-        "Sets the current beat pulse value to `$0`.");
 
     sVar("BeatPulseDelay", &HexagonGameStatus::beatPulseDelay,
         "Gets the current beat pulse delay value, which will vary between "

--- a/src/SSVOpenHexagon/Core/LuaScripting.cpp
+++ b/src/SSVOpenHexagon/Core/LuaScripting.cpp
@@ -909,6 +909,12 @@ static void initLevelControl(
 
     const auto sVar = makeLuaAccessor(lua, status, "l");
 
+    sVar("Pulse", &HexagonGameStatus::pulse,
+        "Gets the current pulse value, which will vary between "
+        "`l_getPulseMin()` and `l_getPulseMax()` unless manually overridden.",
+
+        "Sets the current pulse value to `$0`.");
+
     sVar("PulseDirection", &HexagonGameStatus::pulseDirection,
         "Gets the current pulse direction value, which will either be `-1` or "
         "`1` unless manually overridden.",
@@ -921,6 +927,13 @@ static void initLevelControl(
         "`0` and `l_getPulseDelayMax()` unless manually overridden.",
 
         "Sets the current pulse delay value to `$0`.");
+
+    sVar("BeatPulse", &HexagonGameStatus::beatPulse,
+        "Gets the current beat pulse value, which will vary between `0` and "
+        "`l_getBeatPulseMax()` unless manually overridden.",
+
+        "Sets the current beat pulse value to `$0`.");
+
 
     sVar("BeatPulseDelay", &HexagonGameStatus::beatPulseDelay,
         "Gets the current beat pulse delay value, which will vary between "


### PR DESCRIPTION
This one is mainly for a few levels in 1.92 that use these effects to an extreme extent, for those I need to be able to set the pulse values more than 240 times per second.