### PR TITLE
Add text shaders

### DIFF
--- a/_RELEASE/Packs/base/Scripts/utils.lua
+++ b/_RELEASE/Packs/base/Scripts/utils.lua
@@ -35,7 +35,8 @@ RenderStage = {
     WALLQUADS = 4,
     CAPTRIS = 5,
     PIVOTQUADS = 6,
-    PLAYERTRIS = 7
+    PLAYERTRIS = 7,
+    TEXT = 8
 }
 
 -- An enumerator that defines basic movement values for onInput

--- a/_RELEASE/Packs/experimental/Levels/text_shader.json
+++ b/_RELEASE/Packs/experimental/Levels/text_shader.json
@@ -1,0 +1,12 @@
+{
+    "id": "text_shader",
+    "name": "Text shader test",
+    "description": "",
+    "author": "Baum",
+    "menuPriority": 10,
+    "selectable": true,
+    "styleId": "cw",
+    "musicId": "jackRussel",
+    "luaFile": "Scripts/Levels/text_shader.lua",
+    "difficultyMults": []
+}

--- a/_RELEASE/Packs/experimental/Scripts/Levels/text_shader.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/text_shader.lua
@@ -1,8 +1,9 @@
+u_execDependencyScript("ohvrvanilla", "base", "vittorio romeo", "utils.lua")
+
+
 function onInit()
 	text_shader = shdr_getShaderId("text.frag")
-
-	-- RenderStage 8 is text
-	shdr_setActiveFragmentShader(8, text_shader)
+	shdr_setActiveFragmentShader(RenderStage.TEXT, text_shader)
 
 	-- make sure the text outline color isn't swapping
 	s_setMaxSwapTime(0)

--- a/_RELEASE/Packs/experimental/Scripts/Levels/text_shader.lua
+++ b/_RELEASE/Packs/experimental/Scripts/Levels/text_shader.lua
@@ -1,0 +1,20 @@
+function onInit()
+	text_shader = shdr_getShaderId("text.frag")
+
+	-- RenderStage 8 is text
+	shdr_setActiveFragmentShader(8, text_shader)
+
+	-- make sure the text outline color isn't swapping
+	s_setMaxSwapTime(0)
+end
+
+
+function onUpdate()
+	shdr_setUniformFVec4(text_shader, "color0", s_getColor(0))
+	shdr_setUniformF(text_shader, "time", l_getLevelTime())
+end
+
+
+function onLoad()
+	e_messageAddImportant("test", 1000)
+end

--- a/_RELEASE/Packs/experimental/Shaders/text.frag
+++ b/_RELEASE/Packs/experimental/Shaders/text.frag
@@ -1,0 +1,29 @@
+#version 130
+uniform vec4 color0;
+uniform sampler2D font;
+uniform float time;
+
+vec4 getColorFromHue(const float hue) {
+    int i = int(hue * 6.f);
+
+    float f = (hue * 6.f) - i;
+    float q = 1.f - f;
+    float t = f;
+
+    switch(i)
+    {
+        case 0: return vec4(1.f, t, 0.f, 1.f);
+        case 1: return vec4(q, 1.f, 0.f, 1.f);
+        case 2: return vec4(0.f, 1.f, t, 1.f);
+        case 3: return vec4(0.f, q, 1.f, 1.f);
+        case 4: return vec4(t, 0.f, 1.f, 1.f);
+    }
+
+    return vec4(1.f, 0.f, q, 1.f);
+}
+
+void main() {
+	vec4 fill_color = getColorFromHue(mod(time * 360.f + gl_FragCoord.x + gl_FragCoord.y, 360.f) / 360.f);
+	vec4 color = gl_Color.rgb == color0.rgb / 255.f ? vec4(vec3(1,1,1) - fill_color.rgb, 1.f) : fill_color;
+	gl_FragColor = color * texture(font, gl_TexCoord[0].xy);
+}

--- a/include/SSVOpenHexagon/Core/HGStatus.hpp
+++ b/include/SSVOpenHexagon/Core/HGStatus.hpp
@@ -33,8 +33,9 @@ enum class RenderStage : std::size_t
     CapTris = 5,
     PivotQuads = 6,
     PlayerTris = 7,
+    Text = 8,
 
-    Count = 8
+    Count = 9
 };
 
 struct HexagonGameStatus

--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -377,12 +377,12 @@ private:
     void sideChange(unsigned int mSideNumber);
 
     // Draw methods
-    void drawText_TimeAndStatus(const sf::Color& offsetColor);
-    void drawText_Message(const sf::Color& offsetColor);
-    void drawText_PersonalBest(const sf::Color& offsetColor);
-    void drawText();
+    void drawText_TimeAndStatus(const sf::Color& offsetColor, const sf::RenderStates& mStates);
+    void drawText_Message(const sf::Color& offsetColor, const sf::RenderStates& mStates);
+    void drawText_PersonalBest(const sf::Color& offsetColor, const sf::RenderStates& mStates);
+    void drawText(const sf::RenderStates& mStates);
     void drawKeyIcons();
-    void drawLevelInfo();
+    void drawLevelInfo(const sf::RenderStates& mStates);
     void drawParticles();
     void drawTrailParticles();
     void drawSwapParticles();

--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -276,7 +276,7 @@ void HexagonGame::draw()
     window->setView(overlayCamera->apply());
 
     drawParticles();
-    drawText();
+    drawText(getRenderStates(RenderStage::Text));
 
     // ------------------------------------------------------------------------
     // Draw key icons.
@@ -289,7 +289,7 @@ void HexagonGame::draw()
     // Draw level info.
     if(Config::getShowLevelInfo() || mustShowReplayUI())
     {
-        drawLevelInfo();
+        drawLevelInfo(getRenderStates(RenderStage::Text));
     }
 
     // ------------------------------------------------------------------------
@@ -380,14 +380,14 @@ void HexagonGame::drawKeyIcons()
     }
 }
 
-void HexagonGame::drawLevelInfo()
+void HexagonGame::drawLevelInfo(const sf::RenderStates& mStates)
 {
-    render(levelInfoRectangle);
-    render(levelInfoTextLevel);
-    render(levelInfoTextPack);
-    render(levelInfoTextAuthor);
-    render(levelInfoTextBy);
-    render(levelInfoTextDM);
+    render(levelInfoRectangle, mStates);
+    render(levelInfoTextLevel, mStates);
+    render(levelInfoTextPack, mStates);
+    render(levelInfoTextAuthor, mStates);
+    render(levelInfoTextBy, mStates);
+    render(levelInfoTextDM, mStates);
 }
 
 void HexagonGame::drawParticles()
@@ -595,7 +595,7 @@ void HexagonGame::updateText(ssvu::FT mFT)
     }
 }
 
-void HexagonGame::drawText_TimeAndStatus(const sf::Color& offsetColor)
+void HexagonGame::drawText_TimeAndStatus(const sf::Color& offsetColor, const sf::RenderStates& mStates)
 {
     if(Config::getDrawTextOutlines())
     {
@@ -629,7 +629,7 @@ void HexagonGame::drawText_TimeAndStatus(const sf::Color& offsetColor)
         timeText.setOrigin(ssvs::getLocalNW(timeText));
         timeText.setPosition({padding, padding});
 
-        render(timeText);
+        render(timeText, mStates);
     }
 
     if(Config::getShowStatusText())
@@ -638,7 +638,7 @@ void HexagonGame::drawText_TimeAndStatus(const sf::Color& offsetColor)
         text.setOrigin(ssvs::getLocalNW(text));
         text.setPosition({padding, ssvs::getGlobalBottom(timeText) + padding});
 
-        render(text);
+        render(text, mStates);
     }
 
     if(Config::getShowFPS())
@@ -656,7 +656,7 @@ void HexagonGame::drawText_TimeAndStatus(const sf::Color& offsetColor)
             fpsText.setPosition({padding, Config::getHeight() - padding});
         }
 
-        render(fpsText);
+        render(fpsText, mStates);
     }
 
     if(mustShowReplayUI())
@@ -700,32 +700,32 @@ static void drawTextMessagePBImpl(sf::Text& text, const sf::Color& offsetColor,
     fRender(text);
 }
 
-void HexagonGame::drawText_Message(const sf::Color& offsetColor)
+void HexagonGame::drawText_Message(const sf::Color& offsetColor, const sf::RenderStates& mStates)
 {
     drawTextMessagePBImpl(messageText, offsetColor,
         {Config::getWidth() / 2.f, Config::getHeight() / 5.5f}, getColorText(),
-        1.f /* outlineThickness */, [this](sf::Text& t) { render(t); });
+        1.f /* outlineThickness */, [this, &mStates](sf::Text& t) { render(t, mStates); });
 }
 
-void HexagonGame::drawText_PersonalBest(const sf::Color& offsetColor)
+void HexagonGame::drawText_PersonalBest(const sf::Color& offsetColor, const sf::RenderStates& mStates)
 {
     drawTextMessagePBImpl(pbText, offsetColor,
         {Config::getWidth() / 2.f,
             Config::getHeight() - Config::getHeight() / 4.f},
         getColorText(), 4.f /* outlineThickness */,
-        [this](sf::Text& t) { render(t); });
+        [this, &mStates](sf::Text& t) { render(t, mStates); });
 }
 
-void HexagonGame::drawText()
+void HexagonGame::drawText(const sf::RenderStates& mStates)
 {
     const sf::Color offsetColor{
         Config::getBlackAndWhite() || styleData.getColors().empty()
             ? sf::Color::Black
             : getColor(0)};
 
-    drawText_TimeAndStatus(offsetColor);
-    drawText_Message(offsetColor);
-    drawText_PersonalBest(offsetColor);
+    drawText_TimeAndStatus(offsetColor, mStates);
+    drawText_Message(offsetColor, mStates);
+    drawText_PersonalBest(offsetColor, mStates);
 }
 
 } // namespace hg

--- a/src/SSVOpenHexagon/Core/HGGraphics.cpp
+++ b/src/SSVOpenHexagon/Core/HGGraphics.cpp
@@ -670,7 +670,7 @@ void HexagonGame::drawText_TimeAndStatus(const sf::Color& offsetColor, const sf:
         replayText.setOrigin(ssvs::getLocalCenterE(replayText));
         replayText.setPosition(ssvs::getGlobalCenterW(replayIcon) -
                                sf::Vector2f{replayPadding, 0});
-        render(replayText);
+        render(replayText, mStates);
     }
 }
 


### PR DESCRIPTION
This pr adds the ability to modify the text color with fragment shaders. However it is a bit more unintuitive than the other RenderStages. So a shader that sets the outline to red and the text to green could look like this:
```glsl
#version 130
uniform vec4 color0;
uniform sampler2D font;


void main()
{
	vec4 color = gl_Color.rgb == color0.rgb ? vec4(1,0,0,1) : vec4(0,1,0,1);
	gl_FragColor = color * texture(font, gl_TexCoord[0].xy);
}
```
with `color0` being `s_getColor(0)` in order to set an outline color.