### PR TITLE
Fix replays not saving or saving twice

### DIFF
--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -424,6 +424,7 @@ private:
 private:
     void performPlayerSwap(const bool mPlaySound);
     void performPlayerKill();
+    void saveReplay();
 
     Utils::FastVertexVectorTris backgroundTris;
     Utils::FastVertexVectorTris wallQuads;

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -537,6 +537,17 @@ void HexagonGame::playPackSoundOverride(
 void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
     bool mFirstPlay, float mDifficultyMult, bool executeLastReplay)
 {
+    // Save replay when restarting without having died
+    if(!mFirstPlay && shouldSaveScore() && !status.hasDied)
+    {
+        (void)death_saveScoreIfNeeded(); // Saves local best
+
+        const replay_file rf = death_createReplayFile();
+
+        ssvu::lo("Replay") << "Attempting to send and save replay...\n";
+        death_sendAndSaveReplay(rf);
+    }
+
     SSVOH_ASSERT(assets.isValidPackId(mPackId));
     SSVOH_ASSERT(assets.isValidLevelId(mId));
 
@@ -1220,7 +1231,7 @@ void HexagonGame::goToMenu(bool mSendScores, bool mError)
 
     calledDeprecatedFunctions.clear();
 
-    if(mSendScores && !mError && shouldSaveScore())
+    if(mSendScores && !mError && shouldSaveScore() && !status.hasDied)
     {
         (void)death_saveScoreIfNeeded(); // Saves local best
 

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -534,11 +534,9 @@ void HexagonGame::playPackSoundOverride(
     }
 }
 
-void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
-    bool mFirstPlay, float mDifficultyMult, bool executeLastReplay)
+void HexagonGame::saveReplay()
 {
-    // Save replay when restarting without having died
-    if(!mFirstPlay && shouldSaveScore() && !status.hasDied)
+    if(shouldSaveScore() && !status.hasDied)
     {
         (void)death_saveScoreIfNeeded(); // Saves local best
 
@@ -546,6 +544,16 @@ void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
 
         ssvu::lo("Replay") << "Attempting to send and save replay...\n";
         death_sendAndSaveReplay(rf);
+    }
+}
+
+void HexagonGame::newGame(const std::string& mPackId, const std::string& mId,
+    bool mFirstPlay, float mDifficultyMult, bool executeLastReplay)
+{
+    // Save replay when restarting without having died
+    if(!mFirstPlay)
+    {
+        saveReplay();
     }
 
     SSVOH_ASSERT(assets.isValidPackId(mPackId));
@@ -1231,14 +1239,9 @@ void HexagonGame::goToMenu(bool mSendScores, bool mError)
 
     calledDeprecatedFunctions.clear();
 
-    if(mSendScores && !mError && shouldSaveScore() && !status.hasDied)
+    if(mSendScores && !mError)
     {
-        (void)death_saveScoreIfNeeded(); // Saves local best
-
-        const replay_file rf = death_createReplayFile();
-
-        ssvu::lo("Replay") << "Attempting to send and save replay...\n";
-        death_sendAndSaveReplay(rf);
+        saveReplay();
     }
 
     // Stop infinite feedback from occurring if the error is happening on


### PR DESCRIPTION
This PR fixes replays saving twice when dying and then exiting to menu and replays not saving when restarting without dying.
This way counting replay files will actually give the amount of attempts in a level.
Should fix #371.