### PR TITLE
Fix text appearing in wrong position for a tick

### DIFF
--- a/src/SSVOpenHexagon/Core/HGUpdate.cpp
+++ b/src/SSVOpenHexagon/Core/HGUpdate.cpp
@@ -150,8 +150,6 @@ void HexagonGame::update(ssvu::FT mFT, const float timescale)
 
     // ------------------------------------------------------------------------
 
-    updateText(mFT);
-
     if(mustStart)
     {
         mustStart = false;
@@ -375,6 +373,8 @@ void HexagonGame::update(ssvu::FT mFT, const float timescale)
             backgroundCamera->update(mFT);
         }
     }
+
+    updateText(mFT);
 
     if(status.started)
     {


### PR DESCRIPTION
This PR fixes the bug where a message appears at the wrong position at first and is positioned correctly in the next tick.
This bug is especially noticable in levels that create new messages very frequently.