### PR TITLE
Fix wrong author in level info

### DIFF
--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -217,7 +217,7 @@ void HexagonGame::updateLevelInfo()
         ssvs::getGlobalSW(levelInfoTextLevel) + sf::Vector2f{0.f, tPadding});
 
     prepareText(
-        levelInfoTextAuthor, 20.f, trim(Utils::toUppercase(getPackAuthor())));
+        levelInfoTextAuthor, 20.f, trim(Utils::toUppercase(levelData->author)));
     levelInfoTextAuthor.setOrigin(ssvs::getLocalSE(levelInfoTextAuthor));
     levelInfoTextAuthor.setPosition(ssvs::getGlobalSE(levelInfoRectangle) -
                                     sf::Vector2f{tPadding, tPadding});
@@ -1053,7 +1053,8 @@ void HexagonGame::death_sendAndSaveReplay(const replay_file& rf)
 [[nodiscard]] bool HexagonGame::death_saveReplay(
     const std::string& filename, const compressed_replay_file& crf)
 {
-    std::string dirPath = "Replays/" + levelId + "/" + diffFormat(difficultyMult) + "x/";
+    std::string dirPath =
+        "Replays/" + levelId + "/" + diffFormat(difficultyMult) + "x/";
     std::filesystem::create_directories(dirPath);
     std::filesystem::path p;
     p /= dirPath;


### PR DESCRIPTION
The level info during gameplay/replay shows the pack author instead of the level author. This PR makes it show the level author instead.