### PR TITLE
fix dependency shaders

### DIFF
--- a/src/SSVOpenHexagon/Core/LuaScripting.cpp
+++ b/src/SSVOpenHexagon/Core/LuaScripting.cpp
@@ -1283,7 +1283,7 @@ static void initShaders(Lua::LuaContext& lua, HGAssets& assets,
                 return;
             };
 
-            Utils::withDependencyScriptFilename(setResult,
+            Utils::withDependencyShaderFilename(setResult,
                 execScriptPackPathContext, assets, fGetPackData(),
                 packDisambiguator, packName, packAuthor, shaderFilename);
 


### PR DESCRIPTION
For some reason the game looked for dependency shaders in the scripts folder, this should be fixed with this PR.