### PR TITLE
Fix replay path issues on windows

### DIFF
--- a/include/SSVOpenHexagon/Core/HexagonGame.hpp
+++ b/include/SSVOpenHexagon/Core/HexagonGame.hpp
@@ -379,9 +379,12 @@ private:
     void sideChange(unsigned int mSideNumber);
 
     // Draw methods
-    void drawText_TimeAndStatus(const sf::Color& offsetColor, const sf::RenderStates& mStates);
-    void drawText_Message(const sf::Color& offsetColor, const sf::RenderStates& mStates);
-    void drawText_PersonalBest(const sf::Color& offsetColor, const sf::RenderStates& mStates);
+    void drawText_TimeAndStatus(
+        const sf::Color& offsetColor, const sf::RenderStates& mStates);
+    void drawText_Message(
+        const sf::Color& offsetColor, const sf::RenderStates& mStates);
+    void drawText_PersonalBest(
+        const sf::Color& offsetColor, const sf::RenderStates& mStates);
     void drawText(const sf::RenderStates& mStates);
     void drawKeyIcons();
     void drawLevelInfo(const sf::RenderStates& mStates);
@@ -472,7 +475,7 @@ public:
     [[nodiscard]] bool death_sendReplay(
         const std::string& levelValidator, const compressed_replay_file& crf);
     [[nodiscard]] bool death_saveReplay(
-        const std::string& filename, const compressed_replay_file& crf);
+        std::string filename, const compressed_replay_file& crf);
 
     struct GameExecutionResult
     {

--- a/src/SSVOpenHexagon/Core/HexagonGame.cpp
+++ b/src/SSVOpenHexagon/Core/HexagonGame.cpp
@@ -1051,9 +1051,16 @@ void HexagonGame::death_sendAndSaveReplay(const replay_file& rf)
 }
 
 [[nodiscard]] bool HexagonGame::death_saveReplay(
-    const std::string& filename, const compressed_replay_file& crf)
+    std::string filename, const compressed_replay_file& crf)
 {
-    std::string dirPath = "Replays/" + levelId + "/" + diffFormat(difficultyMult) + "x/";
+    std::string dirPath =
+        "Replays/" + levelId + "/" + diffFormat(difficultyMult) + "x/";
+    // Replace invalid characters for windows file paths
+    for(const auto c : {':', '*', '?', '"', '<', '>', '|'})
+    {
+        std::replace(dirPath.begin(), dirPath.end(), c, ' ');
+        std::replace(filename.begin(), filename.end(), c, ' ');
+    }
     std::filesystem::create_directories(dirPath);
     std::filesystem::path p;
     p /= dirPath;


### PR DESCRIPTION
Some testing in wine and on windows by other people has revealed that windows doesn't like certain characters in file paths. However some 1.92 packs use these in their name/id, so I need this to be fixed without changing that, which is what this PR does. It just replaces the invalid characters with spaces now.